### PR TITLE
Corrects diagnosand label in randomized_response

### DIFF
--- a/tab_inspect.R
+++ b/tab_inspect.R
@@ -260,8 +260,8 @@ inspectTab <- function(input, output, session, design_tab_proxy) {
         } else {
             defs <- design_tab_proxy$react$design_argdefinitions
             min_int <- defs$inspector_min[defs$names == first_arg]
-            max_int <- defs$inspector_max[defs$names == first_arg]
             step_int <- defs$inspector_step[defs$names == first_arg]
+            max_int <- min_int + 4*step_int
             defaults[first_arg] <- sprintf('%d, %d ... %d', min_int, min_int + step_int, max_int)
         }
         


### PR DESCRIPTION
See #65. The existing approach would take names of formals from the diagnosand declaration call, which only works if users are defining diagnosand expressions, and not when they use the arguments `select` or `subtract` in `declare_diagnosis().`

Edited so that when diagnosands are not set to default, we run a sims = 2 diagnosis and take the labels from the diagnosand data frame. More fool-proof though does require diagnosis time. Happy to revise if anyone has a better suggestion.